### PR TITLE
unique 제약조건 삭제

### DIFF
--- a/src/main/java/com/sparta/springweb/model/User.java
+++ b/src/main/java/com/sparta/springweb/model/User.java
@@ -17,7 +17,7 @@ public class User extends Timestamped {
     private Long id;
 
     // 반드시 값을 가지도록 합니다.
-    @Column(nullable = false, unique = true)
+    @Column(nullable = false)
     private String username;
 
     @Column(nullable = false)


### PR DESCRIPTION
익셉션 처리로 unique 제약조건을 제거해도 동일한 아이디의 회원가입은 처리되지 않습니다.
아래 에러 발생이유로 해당 제약 조건을 삭제합니다.
`Specified key was too long; max key length is 1000 bytes`