### PR TITLE
#5: 게시글, 댓글, 대댓글 좋아요 등록/취소 기능 구현

### DIFF
--- a/src/main/java/com/sparta/springweb/controller/CommentController.java
+++ b/src/main/java/com/sparta/springweb/controller/CommentController.java
@@ -1,7 +1,7 @@
 package com.sparta.springweb.controller;
 
+import com.sparta.springweb.dto.CommentDetailResponseDto;
 import com.sparta.springweb.dto.CommentRequestDto;
-import com.sparta.springweb.dto.CommentResponseDto;
 import com.sparta.springweb.global.common.response.ApiUtils;
 import com.sparta.springweb.global.common.response.CommonResponse;
 import com.sparta.springweb.global.error.exception.ErrorCode;
@@ -13,8 +13,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
-
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/api/comments")
@@ -22,9 +20,15 @@ public class CommentController {
     private final CommentService commentService;
 
     // 게시글 id 로 댓글 조회
-    @GetMapping("/{postId}")
-    public CommonResponse<List<CommentResponseDto>> getComment(@PathVariable Long postId) {
-        return ApiUtils.success(200, commentService.getCommentByPostId(postId));
+//    @GetMapping("/{postId}")
+//    public CommonResponse<List<CommentResponseDto>> getComment(@PathVariable Long postId) {
+//        return ApiUtils.success(200, commentService.getCommentByPostId(postId));
+//    }
+
+    // 댓글 조회
+    @GetMapping("/{id}")
+    public CommonResponse<CommentDetailResponseDto> viewCommentDetail(@PathVariable Long id) {
+        return ApiUtils.success(200, commentService.viewCommentDetail(id));
     }
 
     // 댓글 작성

--- a/src/main/java/com/sparta/springweb/controller/LikeController.java
+++ b/src/main/java/com/sparta/springweb/controller/LikeController.java
@@ -1,0 +1,51 @@
+package com.sparta.springweb.controller;
+
+import com.sparta.springweb.global.common.response.ApiUtils;
+import com.sparta.springweb.global.common.response.CommonResponse;
+import com.sparta.springweb.global.error.exception.ErrorCode;
+import com.sparta.springweb.global.error.exception.InvalidValueException;
+import com.sparta.springweb.security.UserDetailsImpl;
+import com.sparta.springweb.service.LikeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/posts")
+public class LikeController {
+    private final LikeService likeService;
+
+    @PostMapping("/{postId}/likes")
+    public CommonResponse<?> PostLike(@PathVariable Long postId, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        if (userDetails == null) {
+            throw new InvalidValueException(ErrorCode.HANDLE_ACCESS_DENIED);
+        }
+
+        likeService.postLike(postId, userDetails.getUser().getId());
+        return ApiUtils.success(200, null);
+    }
+
+    @PostMapping("/{postId}/{commentId}/likes")
+    public CommonResponse<?> CommentLike(@PathVariable Long postId, @PathVariable Long commentId, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        if (userDetails == null) {
+            throw new InvalidValueException(ErrorCode.HANDLE_ACCESS_DENIED);
+        }
+
+        likeService.commentLike(postId, commentId, userDetails.getUser().getId());
+        return ApiUtils.success(200, null);
+    }
+
+    @PostMapping("/{postId}/{commentId}/{replyId}/likes")
+    public CommonResponse<?> replyLike(@PathVariable Long postId, @PathVariable Long commentId, @PathVariable Long replyId, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        if (userDetails == null) {
+            throw new InvalidValueException(ErrorCode.HANDLE_ACCESS_DENIED);
+        }
+
+        likeService.replyLike(postId, commentId, replyId, userDetails.getUser().getId());
+        return ApiUtils.success(200, null);
+    }
+}

--- a/src/main/java/com/sparta/springweb/controller/PostController.java
+++ b/src/main/java/com/sparta/springweb/controller/PostController.java
@@ -1,6 +1,7 @@
 package com.sparta.springweb.controller;
 
 
+import com.sparta.springweb.dto.PostDetailResponseDto;
 import com.sparta.springweb.dto.PostRequestDto;
 import com.sparta.springweb.dto.PostResponseDto;
 import com.sparta.springweb.dto.PostUpdateRequestDto;
@@ -35,9 +36,14 @@ public class PostController {
 
     // 게시글 디테일 조회
     @GetMapping("/{id}")
-    public CommonResponse<PostResponseDto> post(@PathVariable Long id) {
-        return ApiUtils.success(200, postService.getPostById(id));
+    public CommonResponse<PostDetailResponseDto> viewPostDetail(@PathVariable Long id) {
+        return ApiUtils.success(200, postService.viewPostDetail(id));
     }
+
+//    @GetMapping("/{id}")
+//    public CommonResponse<PostResponseDto> post(@PathVariable Long id) {
+//        return ApiUtils.success(200, postService.getPostById(id));
+//    }
 
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping(consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})

--- a/src/main/java/com/sparta/springweb/dto/CommentDetailResponseDto.java
+++ b/src/main/java/com/sparta/springweb/dto/CommentDetailResponseDto.java
@@ -1,0 +1,31 @@
+package com.sparta.springweb.dto;
+
+import com.sparta.springweb.model.Comment;
+import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@Data
+public class CommentDetailResponseDto {
+
+    private final String name;
+    private final String content;
+
+    private Long countCommentLike;
+
+    private List<ReplyResponseDto> replyList;
+
+    public CommentDetailResponseDto(Comment comment,
+                                    Long countCommentLike,
+                                    List<ReplyResponseDto> replyList) {
+        this.name = comment.getUsername();
+        this.content = comment.getComment();
+        this.countCommentLike = countCommentLike;
+        this.replyList = replyList;
+
+    }
+}

--- a/src/main/java/com/sparta/springweb/dto/CommentLikeRequestDto.java
+++ b/src/main/java/com/sparta/springweb/dto/CommentLikeRequestDto.java
@@ -1,0 +1,15 @@
+package com.sparta.springweb.dto;
+
+import com.sparta.springweb.model.Comment;
+import com.sparta.springweb.model.User;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@AllArgsConstructor
+@Getter
+@Setter
+public class CommentLikeRequestDto {
+    private User user;
+    private Comment comment;
+}

--- a/src/main/java/com/sparta/springweb/dto/CommentLikeResponseDto.java
+++ b/src/main/java/com/sparta/springweb/dto/CommentLikeResponseDto.java
@@ -1,0 +1,14 @@
+package com.sparta.springweb.dto;
+
+import lombok.Getter;
+
+@Getter
+public class CommentLikeResponseDto {
+    private Long commentId;
+    private Long likeCount;
+
+    public CommentLikeResponseDto(Long commentId, Long likeCount) {
+        this.commentId = commentId;
+        this.likeCount = likeCount;
+    }
+}

--- a/src/main/java/com/sparta/springweb/dto/CommentLikeUserDto.java
+++ b/src/main/java/com/sparta/springweb/dto/CommentLikeUserDto.java
@@ -1,0 +1,15 @@
+package com.sparta.springweb.dto;
+
+import com.sparta.springweb.model.CommentLike;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class CommentLikeUserDto {
+    private Long userId;
+
+    public CommentLikeUserDto(CommentLike commentLike) {
+        this.userId = commentLike.getUser().getId();
+    }
+}

--- a/src/main/java/com/sparta/springweb/dto/CommentResponseDto.java
+++ b/src/main/java/com/sparta/springweb/dto/CommentResponseDto.java
@@ -3,21 +3,26 @@ package com.sparta.springweb.dto;
 import com.sparta.springweb.model.Comment;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.Setter;
 
+@Setter
 @Getter
 public class CommentResponseDto {
     private final Long id;
     private final String name;
     private final String content;
 
+    private Long countCommentLike;
+
     @Builder
-    public CommentResponseDto(Long id, String name, String content) {
-        this.id = id;
-        this.name = name;
-        this.content = content;
+    public CommentResponseDto(Comment comment, Long countCommentLike) {
+        this.id = comment.getId();
+        this.name = comment.getUsername();
+        this.content = comment.getComment();
+        this.countCommentLike = countCommentLike;
     }
 
-    public static CommentResponseDto createDTO(Comment comment) {
-        return new CommentResponseDto(comment.getId(), comment.getUsername(), comment.getComment());
-    }
+//    public static CommentResponseDto createDTO(Comment comment) {
+//        return new CommentResponseDto(comment.getId(), comment.getUsername(), comment.getComment());
+//    }
 }

--- a/src/main/java/com/sparta/springweb/dto/PostDetailResponseDto.java
+++ b/src/main/java/com/sparta/springweb/dto/PostDetailResponseDto.java
@@ -2,20 +2,26 @@ package com.sparta.springweb.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.sparta.springweb.model.Post;
-import lombok.Builder;
+import lombok.Data;
 import lombok.Getter;
+import lombok.Setter;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Getter
-public class PostResponseDto {
+@Setter
+@Data
+public class PostDetailResponseDto {
     private final Long id;
-    private final String name;
-    private final String title;
-    private final String content;
-    private final String filePath;
 
-    private final int countReply;
+    private final String name;
+
+    private final String title;
+
+    private final String content;
+
+    private final String filePath;
 
     private Long countPostLike;
 
@@ -25,8 +31,12 @@ public class PostResponseDto {
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     private final LocalDateTime modifiedAt;
 
-    @Builder
-    public PostResponseDto(Post post, int countReply, Long countPostLike) {
+    private List<CommentResponseDto> commentList;
+
+
+    public PostDetailResponseDto(Post post,
+                                 Long countPostLike,
+                                 List<CommentResponseDto> commentList) {
         this.id = post.getId();
         this.title = post.getTitle();
         this.name = post.getName();
@@ -34,7 +44,7 @@ public class PostResponseDto {
         this.content = post.getContent();
         this.createdAt = post.getCreatedAt();
         this.modifiedAt = post.getModifiedAt();
-        this.countReply = countReply;
         this.countPostLike = countPostLike;
+        this.commentList = commentList;
     }
 }

--- a/src/main/java/com/sparta/springweb/dto/PostLikeRequestDto.java
+++ b/src/main/java/com/sparta/springweb/dto/PostLikeRequestDto.java
@@ -1,0 +1,16 @@
+package com.sparta.springweb.dto;
+
+import com.sparta.springweb.model.Post;
+import com.sparta.springweb.model.User;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@AllArgsConstructor
+@Getter
+@Setter
+public class PostLikeRequestDto {
+
+    private User user;
+    private Post post;
+}

--- a/src/main/java/com/sparta/springweb/dto/PostLikeResponseDto.java
+++ b/src/main/java/com/sparta/springweb/dto/PostLikeResponseDto.java
@@ -1,0 +1,14 @@
+package com.sparta.springweb.dto;
+
+import lombok.Getter;
+
+@Getter
+public class PostLikeResponseDto {
+    private Long postId;
+    private Long likeCount;
+
+    public PostLikeResponseDto(Long postId, Long likeCount) {
+        this.postId = postId;
+        this.likeCount = likeCount;
+    }
+}

--- a/src/main/java/com/sparta/springweb/dto/PostLikeUserDto.java
+++ b/src/main/java/com/sparta/springweb/dto/PostLikeUserDto.java
@@ -1,0 +1,15 @@
+package com.sparta.springweb.dto;
+
+import com.sparta.springweb.model.PostLike;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class PostLikeUserDto {
+    private Long userId;
+
+    public PostLikeUserDto(PostLike postLike) {
+        this.userId = postLike.getUser().getId();
+    }
+}

--- a/src/main/java/com/sparta/springweb/dto/ReplyLikeRequestDto.java
+++ b/src/main/java/com/sparta/springweb/dto/ReplyLikeRequestDto.java
@@ -1,0 +1,15 @@
+package com.sparta.springweb.dto;
+
+import com.sparta.springweb.model.Reply;
+import com.sparta.springweb.model.User;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@AllArgsConstructor
+@Getter
+@Setter
+public class ReplyLikeRequestDto {
+    private User user;
+    private Reply reply;
+}

--- a/src/main/java/com/sparta/springweb/dto/ReplyLikeResponseDto.java
+++ b/src/main/java/com/sparta/springweb/dto/ReplyLikeResponseDto.java
@@ -1,0 +1,14 @@
+package com.sparta.springweb.dto;
+
+import lombok.Getter;
+
+@Getter
+public class ReplyLikeResponseDto {
+    private Long replyId;
+    private Long likeCount;
+
+    public ReplyLikeResponseDto(Long replyId, Long likeCount) {
+        this.replyId = replyId;
+        this.likeCount = likeCount;
+    }
+}

--- a/src/main/java/com/sparta/springweb/dto/ReplyLikeUserDto.java
+++ b/src/main/java/com/sparta/springweb/dto/ReplyLikeUserDto.java
@@ -1,0 +1,15 @@
+package com.sparta.springweb.dto;
+
+import com.sparta.springweb.model.ReplyLike;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ReplyLikeUserDto {
+    private Long userId;
+
+    public ReplyLikeUserDto(ReplyLike replyLike) {
+        this.userId = replyLike.getUser().getId();
+    }
+}

--- a/src/main/java/com/sparta/springweb/dto/ReplyResponseDto.java
+++ b/src/main/java/com/sparta/springweb/dto/ReplyResponseDto.java
@@ -1,18 +1,25 @@
 package com.sparta.springweb.dto;
 
+import com.sparta.springweb.model.Reply;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.Setter;
 
+@Setter
 @Getter
 public class ReplyResponseDto {
     private final Long id;
     private final String username;
     private final String content;
 
+    private Long countReplyLike;
+
     @Builder
-    public ReplyResponseDto(Long id,String username, String content) {
-        this.id = id;
-        this.username = username;
-        this.content = content;
+    public ReplyResponseDto(Reply reply, Long countReplyLike) {
+        this.id = reply.getId();
+        this.username = reply.getUsername();
+        this.content = reply.getContent();
+        this.countReplyLike = countReplyLike;
     }
+
 }

--- a/src/main/java/com/sparta/springweb/model/Comment.java
+++ b/src/main/java/com/sparta/springweb/model/Comment.java
@@ -1,5 +1,6 @@
 package com.sparta.springweb.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.sparta.springweb.dto.CommentRequestDto;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -27,6 +28,10 @@ public class Comment extends Timestamped {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "post_id", nullable = false)
     private Post post;
+
+    @OneToMany(mappedBy = "comment", cascade = CascadeType.ALL, orphanRemoval = true)
+    @JsonIgnoreProperties({"comment"})
+    private List<CommentLike> commentLikeList = new ArrayList<>();
 
     @OneToMany(cascade = CascadeType.ALL, mappedBy = "comment", orphanRemoval = true)
     private final List<Reply> replies = new ArrayList<>();

--- a/src/main/java/com/sparta/springweb/model/CommentLike.java
+++ b/src/main/java/com/sparta/springweb/model/CommentLike.java
@@ -1,0 +1,31 @@
+package com.sparta.springweb.model;
+
+import com.sparta.springweb.dto.CommentLikeRequestDto;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Getter
+@NoArgsConstructor
+@Entity(name = "comment_like")
+public class CommentLike {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "comment_id")
+    private Comment comment;
+
+    @Builder
+    public CommentLike(CommentLikeRequestDto requestDto) {
+        this.user = requestDto.getUser();
+        this.comment = requestDto.getComment();
+    }
+}

--- a/src/main/java/com/sparta/springweb/model/Post.java
+++ b/src/main/java/com/sparta/springweb/model/Post.java
@@ -1,5 +1,6 @@
 package com.sparta.springweb.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.Getter;
 import javax.persistence.*;
 import java.util.ArrayList;
@@ -26,6 +27,10 @@ public class Post extends Timestamped {
 
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
     private final List<Comment> comments = new ArrayList<>();
+
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
+    @JsonIgnoreProperties({"post"})
+    private List<PostLike> postLikeList = new ArrayList<>();
 
     protected Post() {}
 

--- a/src/main/java/com/sparta/springweb/model/PostLike.java
+++ b/src/main/java/com/sparta/springweb/model/PostLike.java
@@ -1,0 +1,31 @@
+package com.sparta.springweb.model;
+
+import com.sparta.springweb.dto.PostLikeRequestDto;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Getter
+@NoArgsConstructor
+@Entity(name = "post_like")
+public class PostLike {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id")
+    private Post post;
+
+    @Builder
+    public PostLike(PostLikeRequestDto requestDto) {
+        this.user = requestDto.getUser();
+        this.post = requestDto.getPost();
+    }
+}

--- a/src/main/java/com/sparta/springweb/model/Reply.java
+++ b/src/main/java/com/sparta/springweb/model/Reply.java
@@ -1,8 +1,11 @@
 package com.sparta.springweb.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.Getter;
 import lombok.Setter;
 import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
 
 @Getter
 @Entity
@@ -21,6 +24,10 @@ public class Reply extends Timestamped {
     @JoinColumn(name = "comment_id", nullable = false)
     @ManyToOne(fetch  = FetchType.LAZY)
     private Comment comment;
+
+    @OneToMany(mappedBy = "reply", cascade = CascadeType.ALL, orphanRemoval = true)
+    @JsonIgnoreProperties({"reply"})
+    private List<ReplyLike> ReplyLikeList = new ArrayList<>();
 
     protected Reply() {}
 

--- a/src/main/java/com/sparta/springweb/model/ReplyLike.java
+++ b/src/main/java/com/sparta/springweb/model/ReplyLike.java
@@ -1,0 +1,31 @@
+package com.sparta.springweb.model;
+
+import com.sparta.springweb.dto.ReplyLikeRequestDto;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Getter
+@NoArgsConstructor
+@Entity(name = "reply_like")
+public class ReplyLike {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "reply_id")
+    private Reply reply;
+
+    @Builder
+    public ReplyLike(ReplyLikeRequestDto requestDto) {
+        this.user = requestDto.getUser();
+        this.reply = requestDto.getReply();
+    }
+}

--- a/src/main/java/com/sparta/springweb/repository/CommentLikeRepository.java
+++ b/src/main/java/com/sparta/springweb/repository/CommentLikeRepository.java
@@ -1,0 +1,17 @@
+package com.sparta.springweb.repository;
+
+import com.sparta.springweb.model.Comment;
+import com.sparta.springweb.model.CommentLike;
+import com.sparta.springweb.model.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface CommentLikeRepository extends JpaRepository<CommentLike, Long> {
+    Optional<CommentLike> findByUserAndComment(User user, Comment comment);
+    Long countByComment(Comment comment);
+    List<CommentLike> findAllByComment(Comment comment);
+
+    List<CommentLike> findAllByCommentId(Long id);
+}

--- a/src/main/java/com/sparta/springweb/repository/PostLikeRepository.java
+++ b/src/main/java/com/sparta/springweb/repository/PostLikeRepository.java
@@ -1,0 +1,19 @@
+package com.sparta.springweb.repository;
+
+import com.sparta.springweb.model.Post;
+import com.sparta.springweb.model.PostLike;
+import com.sparta.springweb.model.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
+    Optional<PostLike> findByUserAndPost(User user, Post post);
+
+    Long countByPost(Post post);
+
+    List<PostLike> findAllByPost(Post post);
+
+    List<PostLike> findAllByPostId(Long id);
+}

--- a/src/main/java/com/sparta/springweb/repository/ReplyLikeRepository.java
+++ b/src/main/java/com/sparta/springweb/repository/ReplyLikeRepository.java
@@ -1,0 +1,17 @@
+package com.sparta.springweb.repository;
+
+import com.sparta.springweb.model.Reply;
+import com.sparta.springweb.model.ReplyLike;
+import com.sparta.springweb.model.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ReplyLikeRepository extends JpaRepository<ReplyLike, Long> {
+    Optional<ReplyLike> findByUserAndReply(User user, Reply reply);
+
+    Long countByReply(Reply reply);
+
+    List<ReplyLike> findAllByReply(Reply reply);
+}

--- a/src/main/java/com/sparta/springweb/service/LikeService.java
+++ b/src/main/java/com/sparta/springweb/service/LikeService.java
@@ -1,0 +1,88 @@
+package com.sparta.springweb.service;
+
+import com.sparta.springweb.dto.*;
+import com.sparta.springweb.global.error.exception.EntityNotFoundException;
+import com.sparta.springweb.global.error.exception.ErrorCode;
+import com.sparta.springweb.global.error.exception.InvalidValueException;
+import com.sparta.springweb.model.*;
+import com.sparta.springweb.repository.*;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class LikeService {
+    private final PostLikeRepository postLikeRepository;
+    private final UserRepository userRepository;
+    private final PostRepository postRepository;
+    private final CommentLikeRepository commentLikeRepository;
+    private final CommentRepository commentRepository;
+    private final ReplyRepository replyRepository;
+    private final ReplyLikeRepository replyLikeRepository;
+
+    @Transactional
+    public PostLikeResponseDto postLike(Long postId, Long uid) {
+        User user = userRepository.findById(uid).orElseThrow(
+                () -> new InvalidValueException(ErrorCode.NOT_AUTHORIZED)
+        );
+        Post post = postRepository.findById(postId).orElseThrow(
+                () -> new EntityNotFoundException(ErrorCode.NOTFOUND_POST)
+        );
+
+        PostLike findPostLike = postLikeRepository.findByUserAndPost(user, post).orElse(null);
+
+        if(findPostLike == null) {
+            PostLikeRequestDto requestDto = new PostLikeRequestDto(user, post);
+            PostLike postLike = new PostLike(requestDto);
+            postLikeRepository.save(postLike);
+        } else {
+            postLikeRepository.deleteById(findPostLike.getId());
+        }
+        return new PostLikeResponseDto(postId, postLikeRepository.countByPost(post));
+    }
+
+    @Transactional
+    public CommentLikeResponseDto commentLike(Long postId, Long commentId, Long uid) {
+        User user = userRepository.findById(uid).orElseThrow(
+                () -> new InvalidValueException(ErrorCode.NOT_AUTHORIZED)
+        );
+        Comment comment = commentRepository.findById(commentId).orElseThrow(
+                () -> new EntityNotFoundException(ErrorCode.NOTFOUND_COMMENT)
+        );
+
+        CommentLike findCommentLike = commentLikeRepository.findByUserAndComment(user, comment).orElse(null);
+
+        if(findCommentLike == null) {
+            CommentLikeRequestDto requestDto = new CommentLikeRequestDto(user, comment);
+            CommentLike commentLike = new CommentLike(requestDto);
+            commentLikeRepository.save(commentLike);
+        } else {
+            commentLikeRepository.deleteById(findCommentLike.getId());
+        }
+        return new CommentLikeResponseDto(commentId, commentLikeRepository.countByComment(comment));
+    }
+
+    @Transactional
+    public ReplyLikeResponseDto replyLike(Long postId, Long commentId, Long replyId, Long uid) {
+        User user = userRepository.findById(uid).orElseThrow(
+                () -> new InvalidValueException(ErrorCode.NOT_AUTHORIZED)
+        );
+        Reply reply = replyRepository.findById(replyId).orElseThrow(
+                () -> new EntityNotFoundException(ErrorCode.NOTFOUND_REPLY)
+        );
+
+        ReplyLike findReplyLike = replyLikeRepository.findByUserAndReply(user, reply).orElse(null);
+
+        if(findReplyLike == null) {
+            ReplyLikeRequestDto requestDto = new ReplyLikeRequestDto(user, reply);
+            ReplyLike replyLike = new ReplyLike(requestDto);
+            replyLikeRepository.save(replyLike);
+        } else {
+            replyLikeRepository.deleteById(findReplyLike.getId());
+        }
+        return new ReplyLikeResponseDto(replyId, replyLikeRepository.countByReply(reply));
+    }
+
+}

--- a/src/main/java/com/sparta/springweb/service/PostService.java
+++ b/src/main/java/com/sparta/springweb/service/PostService.java
@@ -1,13 +1,15 @@
 package com.sparta.springweb.service;
 
-import com.sparta.springweb.dto.PostRequestDto;
-import com.sparta.springweb.dto.PostResponseDto;
-import com.sparta.springweb.dto.PostUpdateRequestDto;
+import com.sparta.springweb.dto.*;
 import com.sparta.springweb.global.error.exception.EntityNotFoundException;
 import com.sparta.springweb.global.error.exception.ErrorCode;
 import com.sparta.springweb.global.error.exception.InvalidValueException;
+import com.sparta.springweb.model.Comment;
 import com.sparta.springweb.model.Post;
+import com.sparta.springweb.model.PostLike;
+import com.sparta.springweb.repository.CommentLikeRepository;
 import com.sparta.springweb.repository.CommentRepository;
+import com.sparta.springweb.repository.PostLikeRepository;
 import com.sparta.springweb.repository.PostRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -27,6 +29,9 @@ public class PostService {
     private final CommentRepository commentRepository;
     private final StorageService storageService;
 
+    private final PostLikeRepository postLikeRepository;
+    private final CommentLikeRepository commentLikeRepository;
+
     @Transactional
     public void writePost(PostRequestDto postRequestDto, String username, MultipartFile imageFile) {
         String filePath = "";
@@ -43,13 +48,46 @@ public class PostService {
         for (Post post : posts) {
             // + 댓글 개수 카운팅 (추가 기능)
             int countReply = commentRepository.countByPostId(post.getId());
+            // + 좋아요 개수 카운팅
+            List<PostLikeUserDto> postLikeUserDtos = new ArrayList<>();
+            Long countPostLike = postLikeRepository.countByPost(post);
+            List<PostLike> postLikes = postLikeRepository.findAllByPost(post);
+            for (PostLike postLike : postLikes)
+            {
+                PostLikeUserDto postLikeUserDto = new PostLikeUserDto(postLike);
+                postLikeUserDtos.add(postLikeUserDto);
+            }
             PostResponseDto postResponseDto = PostResponseDto.builder()
                     .post(post)
                     .countReply(countReply)
+                    .countPostLike(countPostLike)
                     .build();
             listContents.add(postResponseDto);
         }
         return listContents;
+    }
+
+    // 게시글 상세 조회
+    public PostDetailResponseDto viewPostDetail(Long id) {
+        Post post = postRepository.findById(id).orElseThrow(
+                () -> new EntityNotFoundException(ErrorCode.NOTFOUND_POST));
+
+        List<PostLikeUserDto> postLikeUserDtos = new ArrayList<>();
+        List<PostLike> postLikes = postLikeRepository.findAllByPostId(id);
+        for (PostLike postLike : postLikes)
+        {
+            PostLikeUserDto postLikeUserDto = new PostLikeUserDto(postLike);
+            postLikeUserDtos.add(postLikeUserDto);
+        }
+        List<Comment> commentList = commentRepository.findAllByPostIdOrderByCreatedAtDesc(id);
+        List<CommentResponseDto> commentResponseDtoList = new ArrayList<>();
+        for (Comment comment : commentList) {
+            Long countCommentLike = commentLikeRepository.countByComment(comment);
+            commentResponseDtoList.add(new CommentResponseDto(comment, countCommentLike));
+        }
+        Long countPostLike = postLikeRepository.countByPost(post);
+
+        return new PostDetailResponseDto(post, countPostLike, commentResponseDtoList);
     }
 
     @Transactional
@@ -83,7 +121,8 @@ public class PostService {
     public PostResponseDto getPostById(Long id) {
         Post post = exists(id);
         int numberOfComments = post.getComments().size();
-        return new PostResponseDto(post, numberOfComments);
+        Long numberOfLikes = Long.valueOf(post.getPostLikeList().size());
+        return new PostResponseDto(post, numberOfComments, numberOfLikes);
     }
 
     @Transactional
@@ -113,4 +152,4 @@ public class PostService {
         }
         return listContents;
     }
-    }
+}

--- a/src/main/java/com/sparta/springweb/service/ReplyService.java
+++ b/src/main/java/com/sparta/springweb/service/ReplyService.java
@@ -1,19 +1,22 @@
 package com.sparta.springweb.service;
 
+import com.sparta.springweb.dto.ReplyLikeUserDto;
 import com.sparta.springweb.dto.ReplyRequestDto;
 import com.sparta.springweb.dto.ReplyResponseDto;
 import com.sparta.springweb.global.error.exception.EntityNotFoundException;
 import com.sparta.springweb.global.error.exception.ErrorCode;
 import com.sparta.springweb.model.Comment;
 import com.sparta.springweb.model.Reply;
+import com.sparta.springweb.model.ReplyLike;
 import com.sparta.springweb.repository.CommentRepository;
+import com.sparta.springweb.repository.ReplyLikeRepository;
 import com.sparta.springweb.repository.ReplyRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -21,9 +24,28 @@ public class ReplyService {
     public final ReplyRepository replyRepository;
     public final CommentRepository commentRepository;
 
+    public final ReplyLikeRepository replyLikeRepository;
+
+    // 대댓글 조회
     public List<ReplyResponseDto> getReplyByCommentId(Long commentId) {
         List<Reply> replies = replyRepository.findAllByCommentId(commentId);
-        return replies.stream().map(m -> new ReplyResponseDto(m.getId(),m.getUsername(), m.getContent())).collect(Collectors.toList());
+        List<ReplyResponseDto> listreplies = new ArrayList<>();
+        for (Reply reply : replies) {
+            List<ReplyLikeUserDto> replyLikeUserDtos = new ArrayList<>();
+            Long countReplyLike = replyLikeRepository.countByReply(reply);
+            List<ReplyLike> replyLikes = replyLikeRepository.findAllByReply(reply);
+            for (ReplyLike replyLike : replyLikes) {
+                ReplyLikeUserDto replyLikeUserDto = new ReplyLikeUserDto(replyLike);
+                replyLikeUserDtos.add(replyLikeUserDto);
+            }
+            ReplyResponseDto replyResponseDto = ReplyResponseDto.builder()
+                    .reply(reply)
+                    .countReplyLike(countReplyLike)
+                    .build();
+            listreplies.add(replyResponseDto);
+        }
+        return listreplies;
+//        return replies.stream().map(m -> new ReplyResponseDto(m.getId(),m.getUsername(), m.getContent())).collect(Collectors.toList());
     }
 
     @Transactional


### PR DESCRIPTION
게시글, 댓글, 대댓글 좋아요 등록/취소 기능을 구현하였습니다.

1.게시글이 존재하지 않을 때는EntityNotFoundException(ErrorCode.NOTFOUND_POST) 메서드를, 댓글이 존재하지 않을 때는 EntityNotFoundException(ErrorCode.NOTFOUND_COMMENT)메서드를, 대댓글이 존재하지 않을 때는   EntityNotFoundException(ErrorCode.NOTFOUND_REPLY)메서드를 사용하여 에러 처리를 하였습니다.

2. 데이터베이스 네이밍 규칙을 참고하여 post_like 테이블(게시글 좋아요), comment_like 테이블(댓글 좋아요), reply_like 테이블(대댓글 좋아요)을 만들었습니다.

3. 영속성 전이를 이용하여 상위 객체 삭제 시 하위 객체가 삭제되도록 하였습니다.
4. 게시글 목록 response에 등록일과 수정일을 나타내라는 요구사항이 있어 이를 추가하였습니다.